### PR TITLE
Change md5withRSA to SHA1withRSA which is the default sig alg.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
@@ -42,7 +42,7 @@ namespace Xamarin.Android.Tasks
 			cmd.AppendSwitchIfNotNull ("-storepass ", StorePass);
 			cmd.AppendSwitchIfNotNull ("-keypass ", KeyPass);
 			cmd.AppendSwitchIfNotNull ("-digestalg ", "SHA1");
-			cmd.AppendSwitchIfNotNull ("-sigalg ", "md5withRSA");
+			cmd.AppendSwitchIfNotNull ("-sigalg ", "SHA1withRSA");
 			cmd.AppendSwitchIfNotNull ("-signedjar ", String.Format ("{0}{1}{2}-Signed-Unaligned.apk", SignedApkDirectory, Path.DirectorySeparatorChar, Path.GetFileNameWithoutExtension (UnsignedApk)));
 
 			cmd.AppendFileNameIfNotNull (UnsignedApk);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
@@ -32,7 +32,9 @@ namespace Xamarin.Android.Tasks
 
 		public string TimestampAuthorityCertificateAlias { get; set; }
 
-		protected override string GenerateCommandLineCommands ()
+        public string SigningAlgorithm { get; set; }
+
+        protected override string GenerateCommandLineCommands ()
 		{
 			var cmd = new CommandLineBuilder ();
 
@@ -42,8 +44,8 @@ namespace Xamarin.Android.Tasks
 			cmd.AppendSwitchIfNotNull ("-storepass ", StorePass);
 			cmd.AppendSwitchIfNotNull ("-keypass ", KeyPass);
 			cmd.AppendSwitchIfNotNull ("-digestalg ", "SHA1");
-			cmd.AppendSwitchIfNotNull ("-sigalg ", "SHA1withRSA");
-			cmd.AppendSwitchIfNotNull ("-signedjar ", String.Format ("{0}{1}{2}-Signed-Unaligned.apk", SignedApkDirectory, Path.DirectorySeparatorChar, Path.GetFileNameWithoutExtension (UnsignedApk)));
+            cmd.AppendSwitchIfNotNull ("-sigalg ", string.IsNullorWitespace(SigningAlgorithm) ? "md5withRSA" : SigningAlgorithm);
+            cmd.AppendSwitchIfNotNull ("-signedjar ", String.Format ("{0}{1}{2}-Signed-Unaligned.apk", SignedApkDirectory, Path.DirectorySeparatorChar, Path.GetFileNameWithoutExtension (UnsignedApk)));
 
 			cmd.AppendFileNameIfNotNull (UnsignedApk);
 			cmd.AppendSwitch (KeyAlias);

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2439,6 +2439,7 @@ because xbuild doesn't support framework reference assemblies.
 		ToolExe="$(JarsignerToolExe)"
 		TimestampAuthorityUrl="$(JarsignerTimestampAuthorityUrl)"
 		TimestampAuthorityCertificateAlias="$(JarsignerTimestampAuthorityCertificateAlias)"
+		SigningAlgorithm="$(_ApkSigningAlgorithm)"
 	/>
 	<Message Text="Signed android package '$(ApkFileSigned)'" />
 	<ItemGroup>


### PR DESCRIPTION
SHA1withRSA is now the default signature algorithm according to this JDK issue: https://bugs.openjdk.java.net/browse/JDK-6560733